### PR TITLE
Feature/forbidden fields check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .lein-failures
 .nrepl-port
 target/
+*.DS_Store

--- a/test/kixi/gwyn/data_test.clj
+++ b/test/kixi/gwyn/data_test.clj
@@ -15,9 +15,9 @@
 (deftest test-for-forbidden-fields
   (testing "csv's have forbidden fields present"
     (let [files (map (fn [x] (.getPath x)) (file-seq (io/file "data/")))
-          csv-files (filter #(re-find #"\.csv$" %) files)]
-      (is (true? (empty? (if (not-empty csv-files)
-                           (let [headers (map #(first (open-csv %)) csv-files)]
-                             (mapcat (fn [x]
-                                       (filter (fn [z] ((set x) z)) forbidden-fields))
-                                     headers)))))))))
+          csv-files (filter (fn [f] (re-find #"\.csv$" f)) files)]
+      (is (empty? (if (not-empty csv-files)
+                    (let [headers (map (comp first open-csv) csv-files)]
+                      (mapcat (fn [x]
+                                (filter (fn [z] ((set x) z)) forbidden-fields))
+                              headers))))))))

--- a/test/kixi/gwyn/data_test.clj
+++ b/test/kixi/gwyn/data_test.clj
@@ -16,7 +16,7 @@
   (testing "csv's have forbidden fields present"
     (let [files (map (fn [x] (.getPath x)) (file-seq (io/file "data/")))
           csv-files (filter (fn [f] (re-find #"\.csv$" f)) files)]
-      (is (empty? (if (not-empty csv-files)
+      (is (empty? (when (not-empty csv-files)
                     (let [headers (map (comp first open-csv) csv-files)]
                       (mapcat (fn [x]
                                 (filter (fn [z] ((set x) z)) forbidden-fields))

--- a/test/kixi/gwyn/data_test.clj
+++ b/test/kixi/gwyn/data_test.clj
@@ -1,0 +1,23 @@
+(ns kixi.gwyn.data-test
+  (:require  [clojure.test :refer :all]
+             [clojure.java.io :as io]
+             [clojure.data.csv :as data-csv]))
+
+(defn open-csv [filename]
+  (with-open [in-file (io/reader filename)]
+    (vec (data-csv/read-csv in-file))))
+
+(def forbidden-fields ["Motive"
+                       "MainCause"
+                       "ParentMainCause"
+                       "MainCauseGroup"])
+
+(deftest test-for-forbidden-fields
+  (testing "csv's have forbidden fields present"
+    (let [files (map (fn [x] (.getPath x)) (file-seq (io/file "data/")))
+          csv-files (filter #(re-find #"\.csv$" %) files)]
+      (is (true? (empty? (if (not-empty csv-files)
+                           (let [headers (map #(first (open-csv %)) csv-files)]
+                             (mapcat (fn [x]
+                                       (filter (fn [z] ((set x) z)) forbidden-fields))
+                                     headers)))))))))


### PR DESCRIPTION
Apollo has indicated that data points corresponding to the following headers should not be made public in any of the data stored in this repo.

Motive
MainCause
ParentMainCause
MainCauseGroup

To help prevent csvs with these headers not being uploaded there is now a test which looks for csv's and tests whether they contain this data, which makes the CircleCI tests fail